### PR TITLE
Utility getters to work with MySQL UTC default

### DIFF
--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerAdjunct.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerAdjunct.cs
@@ -15,8 +15,6 @@ namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
         public uint BeerAdjunctId { get; set; }
         public string Name { get; set; }
         public string Notes { get; set; }
-        public DateTime RowCreated { get; set; }
-        public DateTime RowModified { get; set; }
 
         public virtual ICollection<BeerRecipeAdjunct> BeerRecipeAdjunct { get; set; }
     }

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerGrain.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerGrain.cs
@@ -12,7 +12,5 @@ namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
         public string Manufacturer { get; set; }
         public int? Lovibond { get; set; }
         public decimal? PotentialGravity { get; set; }
-        public DateTime RowCreated { get; set; }
-        public DateTime RowModified { get; set; }
     }
 }

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerHop.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerHop.cs
@@ -15,8 +15,6 @@ namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
         public uint BeerHopId { get; set; }
         public string Name { get; set; }
         public decimal? AlphaAcid { get; set; }
-        public DateTime RowCreated { get; set; }
-        public DateTime RowModified { get; set; }
 
         public virtual ICollection<BeerRecipeHop> BeerRecipeHop { get; set; }
     }

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerRecipe.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerRecipe.cs
@@ -24,8 +24,6 @@ namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
         public decimal? FinalGravity { get; set; }
         public decimal? AlcoholByVolume { get; set; }
         public decimal? BatchSize { get; set; }
-        public DateTime RowCreated { get; set; }
-        public DateTime RowModified { get; set; }
 
         public virtual ICollection<BeerRecipeAdjunct> BeerRecipeAdjunct { get; set; }
         public virtual ICollection<BeerRecipeGrain> BeerRecipeGrain { get; set; }

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerRecipeAdjunct.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerRecipeAdjunct.cs
@@ -13,8 +13,6 @@ namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
         public decimal Amount { get; set; }
         public string AmountUnit { get; set; }
         public string Notes { get; set; }
-        public DateTime RowCreated { get; set; }
-        public DateTime RowModified { get; set; }
 
         public virtual BeerAdjunct BeerAdjunct { get; set; }
         public virtual BeerRecipe BeerRecipe { get; set; }

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerRecipeGrain.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerRecipeGrain.cs
@@ -11,8 +11,6 @@ namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
         public uint BeerRecipeId { get; set; }
         public uint BeerGrainId { get; set; }
         public decimal Amount { get; set; }
-        public DateTime RowCreated { get; set; }
-        public DateTime RowModified { get; set; }
 
         public virtual BeerRecipe BeerRecipe { get; set; }
     }

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerRecipeHop.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerRecipeHop.cs
@@ -13,8 +13,6 @@ namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
         public decimal Amount { get; set; }
         public int? BoilMinute { get; set; }
         public bool? IsDryHop { get; set; }
-        public DateTime RowCreated { get; set; }
-        public DateTime RowModified { get; set; }
 
         public virtual BeerHop BeerHop { get; set; }
         public virtual BeerRecipe BeerRecipe { get; set; }

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerRecipeMashStep.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerRecipeMashStep.cs
@@ -11,8 +11,6 @@ namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
         public uint BeerRecipeId { get; set; }
         public int Temperature { get; set; }
         public int Minutes { get; set; }
-        public DateTime RowCreated { get; set; }
-        public DateTime RowModified { get; set; }
 
         public virtual BeerRecipe BeerRecipe { get; set; }
     }

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerRecipeNote.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerRecipeNote.cs
@@ -10,8 +10,6 @@ namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
         public uint BeerRecipeNoteId { get; set; }
         public uint BeerRecipeId { get; set; }
         public string Note { get; set; }
-        public DateTime RowCreated { get; set; }
-        public DateTime RowModified { get; set; }
 
         public virtual BeerRecipe BeerRecipe { get; set; }
     }

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerRecipeYeast.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerRecipeYeast.cs
@@ -12,8 +12,6 @@ namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
         public uint BeerYeastId { get; set; }
         public decimal? StarterGallons { get; set; }
         public decimal? StarterMaltExtractOunces { get; set; }
-        public DateTime RowCreated { get; set; }
-        public DateTime RowModified { get; set; }
 
         public virtual BeerRecipe BeerRecipe { get; set; }
         public virtual BeerYeast BeerYeast { get; set; }

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerYeast.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/BeerYeast.cs
@@ -15,8 +15,6 @@ namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
         public uint BeerYeastId { get; set; }
         public string Name { get; set; }
         public bool? IsKettleSour { get; set; }
-        public DateTime RowCreated { get; set; }
-        public DateTime RowModified { get; set; }
 
         public virtual ICollection<BeerRecipeYeast> BeerRecipeYeast { get; set; }
     }

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerAdjunctPartial.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerAdjunctPartial.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
+{
+    public partial class BeerAdjunct
+    {
+        private DateTime _rowCreated;
+        private DateTime _rowModified;
+
+        public DateTime RowCreated
+        {
+            get =>
+                (_rowCreated.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowCreated, DateTimeKind.Utc)
+                    : _rowCreated;
+
+            set => _rowCreated = value;
+        }
+
+        public DateTime RowModified
+        {
+            get =>
+                (_rowModified.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowModified, DateTimeKind.Utc)
+                    : _rowModified;
+
+            set => _rowModified = value;
+        }
+    }
+}

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerGrainPartial.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerGrainPartial.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
+{
+    public partial class BeerGrain
+    {
+        private DateTime _rowCreated;
+        private DateTime _rowModified;
+
+        public DateTime RowCreated
+        {
+            get =>
+                (_rowCreated.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowCreated, DateTimeKind.Utc)
+                    : _rowCreated;
+
+            set => _rowCreated = value;
+        }
+
+        public DateTime RowModified
+        {
+            get =>
+                (_rowModified.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowModified, DateTimeKind.Utc)
+                    : _rowModified;
+
+            set => _rowModified = value;
+        }
+    }
+}

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerHopPartial.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerHopPartial.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
+{
+    public partial class BeerHop
+    {
+        private DateTime _rowCreated;
+        private DateTime _rowModified;
+
+        public DateTime RowCreated
+        {
+            get =>
+                (_rowCreated.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowCreated, DateTimeKind.Utc)
+                    : _rowCreated;
+
+            set => _rowCreated = value;
+        }
+
+        public DateTime RowModified
+        {
+            get =>
+                (_rowModified.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowModified, DateTimeKind.Utc)
+                    : _rowModified;
+
+            set => _rowModified = value;
+        }
+    }
+}

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerRecipeAdjunctPartial.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerRecipeAdjunctPartial.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
+{
+    public partial class BeerRecipeAdjunct
+    {
+        private DateTime _rowCreated;
+        private DateTime _rowModified;
+
+        public DateTime RowCreated
+        {
+            get =>
+                (_rowCreated.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowCreated, DateTimeKind.Utc)
+                    : _rowCreated;
+
+            set => _rowCreated = value;
+        }
+
+        public DateTime RowModified
+        {
+            get =>
+                (_rowModified.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowModified, DateTimeKind.Utc)
+                    : _rowModified;
+
+            set => _rowModified = value;
+        }
+    }
+}

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerRecipeGrainPartial.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerRecipeGrainPartial.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
+{
+    public partial class BeerRecipeGrain
+    {
+        private DateTime _rowCreated;
+        private DateTime _rowModified;
+
+        public DateTime RowCreated
+        {
+            get =>
+                (_rowCreated.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowCreated, DateTimeKind.Utc)
+                    : _rowCreated;
+
+            set => _rowCreated = value;
+        }
+
+        public DateTime RowModified
+        {
+            get =>
+                (_rowModified.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowModified, DateTimeKind.Utc)
+                    : _rowModified;
+
+            set => _rowModified = value;
+        }
+    }
+}

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerRecipeHopPartial.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerRecipeHopPartial.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
+{
+    public partial class BeerRecipeHop
+    {
+        private DateTime _rowCreated;
+        private DateTime _rowModified;
+
+        public DateTime RowCreated
+        {
+            get =>
+                (_rowCreated.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowCreated, DateTimeKind.Utc)
+                    : _rowCreated;
+
+            set => _rowCreated = value;
+        }
+
+        public DateTime RowModified
+        {
+            get =>
+                (_rowModified.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowModified, DateTimeKind.Utc)
+                    : _rowModified;
+
+            set => _rowModified = value;
+        }
+    }
+}

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerRecipeMashStepPartial.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerRecipeMashStepPartial.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
+{
+    public partial class BeerRecipeMashStep
+    {
+        private DateTime _rowCreated;
+        private DateTime _rowModified;
+
+        public DateTime RowCreated
+        {
+            get =>
+                (_rowCreated.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowCreated, DateTimeKind.Utc)
+                    : _rowCreated;
+
+            set => _rowCreated = value;
+        }
+
+        public DateTime RowModified
+        {
+            get =>
+                (_rowModified.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowModified, DateTimeKind.Utc)
+                    : _rowModified;
+
+            set => _rowModified = value;
+        }
+    }
+}

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerRecipeNotePartial.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerRecipeNotePartial.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
+{
+    public partial class BeerRecipeNote
+    {
+        private DateTime _rowCreated;
+        private DateTime _rowModified;
+
+        public DateTime RowCreated
+        {
+            get =>
+                (_rowCreated.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowCreated, DateTimeKind.Utc)
+                    : _rowCreated;
+
+            set => _rowCreated = value;
+        }
+
+        public DateTime RowModified
+        {
+            get =>
+                (_rowModified.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowModified, DateTimeKind.Utc)
+                    : _rowModified;
+
+            set => _rowModified = value;
+        }
+    }
+}

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerRecipePartial.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerRecipePartial.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
+{
+    public partial class BeerRecipe
+    {
+        private DateTime _rowCreated;
+        private DateTime _rowModified;
+
+        public DateTime RowCreated
+        {
+            get =>
+                (_rowCreated.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowCreated, DateTimeKind.Utc)
+                    : _rowCreated;
+
+            set => _rowCreated = value;
+        }
+
+        public DateTime RowModified
+        {
+            get =>
+                (_rowModified.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowModified, DateTimeKind.Utc)
+                    : _rowModified;
+
+            set => _rowModified = value;
+        }
+    }
+}

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerRecipeYeastPartial.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerRecipeYeastPartial.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
+{
+    public partial class BeerRecipeYeast
+    {
+        private DateTime _rowCreated;
+        private DateTime _rowModified;
+
+        public DateTime RowCreated
+        {
+            get =>
+                (_rowCreated.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowCreated, DateTimeKind.Utc)
+                    : _rowCreated;
+
+            set => _rowCreated = value;
+        }
+
+        public DateTime RowModified
+        {
+            get =>
+                (_rowModified.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowModified, DateTimeKind.Utc)
+                    : _rowModified;
+
+            set => _rowModified = value;
+        }
+    }
+}

--- a/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerYeastPartial.cs
+++ b/beer-api-dotnet7/BeerStuff.DataAccess/Entities/BeerNetContext/Models/PartialModels/BeerYeastPartial.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace BeerStuff.DataAccess.Entities.BeerNetContext.Models
+{
+    public partial class BeerYeast
+    {
+        private DateTime _rowCreated;
+        private DateTime _rowModified;
+
+        public DateTime RowCreated
+        {
+            get =>
+                (_rowCreated.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowCreated, DateTimeKind.Utc)
+                    : _rowCreated;
+
+            set => _rowCreated = value;
+        }
+
+        public DateTime RowModified
+        {
+            get =>
+                (_rowModified.Kind == DateTimeKind.Unspecified)
+                    ? DateTime.SpecifyKind(_rowModified, DateTimeKind.Utc)
+                    : _rowModified;
+
+            set => _rowModified = value;
+        }
+    }
+}


### PR DESCRIPTION
With row created / row modified managed by the db, MySQL defaults these to UTC.  In the conversion to protobuf timestamp, the DateTime fields in the POCO models have to be "converted" to UTC, and as is, have no offset info when pulled from the db (so timezone/kind is set as unspecified).  

When DateTime.ToUniversalTime is ran, it will re-offset against the local timezone where the application is running, so effectively offsets will be doubled - once when MySQL stores the value and again applied after reading the UTC value.

Providing some getter methods to specify the time zone / kind as UTC when hydrating the POCO models.  Pulling the rowCreated and rowModified fields into a partial class so if/when POCO auto-generation is ran again with all columns specified, it will break the app vs. reintroducing this problem silently.